### PR TITLE
chromecast: fix detection of the homescreen

### DIFF
--- a/lib/chromecast.js
+++ b/lib/chromecast.js
@@ -24,7 +24,12 @@ function update(device, status) {
 
   // Is the device on the home screen?
   function onHomeScreen() {
-    return !!_.find(status.applications, function(a) { return homeIds.indexOf(a.appId) !== -1 });
+    var home = !!_.find(status.applications, function(a) { return homeIds.indexOf(a.appId) !== -1 });
+    logger.debug('Chromecast device is' + (home?'':' NOT') + 'on home screen',
+                 { id: device.id,
+                   chromecast: device.friendlyName
+                 });
+    return home;
   }
 
   // Is it on Dashkiosk but without being able to retrieve a receiver?


### PR DESCRIPTION
As reported by @aguy, the home screen ID has changed on recent
Chromecasts. We try to accommodate not-yet-upgraded Chromecasts and
up-to-date Chromecasts by allowing any of the ID to be detected as the
homescreen.

Should fix #10.
