### PR TITLE
auth.username, not auth.user

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -63,7 +63,7 @@ advanced options, you should put it behind a reverse proxy.
   ``auth.realm``
      Realm to use for HTTP basic authentication.
 
-  ``auth.user``
+  ``auth.username``
      Valid username for authentication.
 
   ``auth.password``


### PR DESCRIPTION
At least auth.username was the only way basic auth would work for me using the latest docker file.