### PR TITLE
Add configuration variable for changing the default url for unassigned

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -105,6 +105,9 @@ to not use the integrated SQLite database.
      Location of a log file where to write logs in JSON format. By
      default, no such file is generated.
 
+ ``default_unassigned_url``
+    Change the default url for the unassigned displays. Default is **/unassigned**
+
 Branding
 --------
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -61,7 +61,8 @@ nconf
            demo: false,
            branding: 'default',
            secret: 'changeThisLameSecretPassphrase!!',
-           forcessl: false
+           forcessl: false,
+           default_unassigned_url: '/unassigned',
          }
        });
 

--- a/lib/models/group.js
+++ b/lib/models/group.js
@@ -5,6 +5,7 @@ var _  = require('lodash'),
     logger = require('../logger'),
     db = require('../db'),
     models = require('../models'),
+    config = require('../config'),
     bus = require('../bus');
 
 // Constructor. Also, name can be an existing DAO instance.
@@ -400,7 +401,7 @@ Group.unassigned = (function() {
           unassigned = new Group(unassigned);
           if (created) {
             return unassigned
-              .addDashboard('/unassigned',
+              .addDashboard(config.get('default_unassigned_url'),
                             { description: 'Dashboards for unassigned display' })
               .then(function() {
                 bus.publish('group.' + unassigned.persistent.id +


### PR DESCRIPTION
Hi Vincent,

I've added a new configuration parameter for configuring the default url for the unassigned displays, from the default /unassigned endpoint to a custom one.
The configuration option is: **default_unassigned_url** with defualt value of "/unassigned".
If you think it could be interesting and useful for others, you may merge the pull request.

Cheers
Alex