### PR TITLE
Update install.rst for jpegtran on Debian/Ubuntu

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -39,7 +39,7 @@ To install it, you need to execute the following step:
      ``optipng`` and ``gifsicle`` from your distribution. For example,
      on Debian::
 
-         $ sudo apt-get libjpeg-progs optipng gifsicle
+         $ sudo apt-get install libjpeg-progs optipng gifsicle
 
   7. Upon success, you will get a ``dist`` directory that you can put on
      some server. It includes both the receiver and the server

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -39,7 +39,7 @@ To install it, you need to execute the following step:
      ``optipng`` and ``gifsicle`` from your distribution. For example,
      on Debian::
 
-         $ sudo apt-get install jpegtran optipng gifsicle
+         $ sudo apt-get libjpeg-progs optipng gifsicle
 
   7. Upon success, you will get a ``dist`` directory that you can put on
      some server. It includes both the receiver and the server


### PR DESCRIPTION
jpegtran on debian / ubuntu seems to now come from libjpeg-progs package instead of jpegtran package (at least from buster)

Suggest Doc update